### PR TITLE
inverted RKT pitch axis

### DIFF
--- a/Software/Container Scripts/Hub_KSP_2_3/04_Analog.ino
+++ b/Software/Container Scripts/Hub_KSP_2_3/04_Analog.ino
@@ -81,7 +81,11 @@ void readAnalog() {
   int raxis2 = (int)Analog[3] << 8 | (int)Analog[4];
   int raxis3 = (int)Analog[5] << 8 | (int)Analog[6];
 
-  Analog_axis1 = convertAnalog(raxis2);
+  if (vehicleType == rocket) {
+    Analog_axis1 = convertAnalog_flipped(raxis2);
+  } else {
+    Analog_axis1 = convertAnalog(raxis2);
+  }
   if (analog_mode == 1) {
     Analog_axis0 = convertAnalog(raxis1);
     Analog_axis2 = convertAnalog(raxis3);

--- a/Software/Container Scripts/Hub_KSP_2_3/settings.h
+++ b/Software/Container Scripts/Hub_KSP_2_3/settings.h
@@ -26,9 +26,9 @@
   // Alternatively, if your throttle lever isn't quite reaching zero or max,
   // you may raise the min values or lower the max values.
 
-  #define throttle_min 310
+  #define throttle_min 315
   #define throttle_max 847
-  #define throttle_pmin 276
+  #define throttle_pmin 281
   #define throttle_pmax 755
 
 

--- a/Software/Container Scripts/Hub_KSP_2_3/settings.h
+++ b/Software/Container Scripts/Hub_KSP_2_3/settings.h
@@ -26,10 +26,10 @@
   // Alternatively, if your throttle lever isn't quite reaching zero or max,
   // you may raise the min values or lower the max values.
 
-  #define throttle_min 280
-  #define throttle_max 894
-  #define throttle_pmin 250
-  #define throttle_pmax 800
+  #define throttle_min 310
+  #define throttle_max 847
+  #define throttle_pmin 276
+  #define throttle_pmax 755
 
 
 //|---------------------|


### PR DESCRIPTION
This is how I edited the pitch axis to be inverted only for RKT mode.

I considered making this customisable via `settings.h` so that the user could provide the bitmask of which modes they wanted to invert, but to do that the definitions of the vehicles would have to be edited here

```
  #define plane 0
  #define rocket 1
  #define rover 2
```

to be compatible with bitmasks (i.e. `plane 1`, `rocket 2` `rover 4`). And since there is so much hardcoding all over the source code against the existing integer values, I didn't want to embark on that.

For my own records if I come back to this one day wondering how I got it to work from Emacs...

```
arduino-cli compile -b arduino:avr:micro
arduino-cli upload -p /dev/ttyACM1 -b arduino:avr:micro -t
```

Something else that's worth noting is that in the VAB the pod holding the Kerbal faces south, and since the camera is actually facing North, everything is backwards. A decent idea (from a navball perspective, maybe not so comfortable for the Kerbals) is to always flip the pods around so that the entrance is on the north side and therefore N(orth) points up on the navball OR to rearrange your camera to point south, like the Kerbal sees. I believe this mismatch between the pod direction and the camera angle is what makes most people believe that the pitch axis is the right way up to begin with ... but if you navigate by looking at the navball rather than the camera then inverting the pitch in RKT mode makes a lot of sense.